### PR TITLE
Fix/ranking/list

### DIFF
--- a/__tests__/helper/boss.js
+++ b/__tests__/helper/boss.js
@@ -51,6 +51,14 @@ const createRaidRecord = () => {
       createdAt: '2022-09-16 19:00',
       updatedAt: '2022-09-16 19:03',
     },
+    {
+      raidRecordId: 7,
+      userId: 2,
+      state: 'start',
+      score: 50,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    },
   ]
 }
 const initData = async () => {

--- a/__tests__/intergration/boss.js
+++ b/__tests__/intergration/boss.js
@@ -10,6 +10,9 @@ describe('boss raid 통합테스트', () => {
       const bossState = await bossStateAPI.getBossState()
       bossRaidCache = {
         bossState: bossState.bossRaids[0],
+        ranking: {
+          topRankerInfoList: [],
+        },
       }
     } catch (err) {
       throw new Error(err)
@@ -72,15 +75,17 @@ describe('boss raid 통합테스트', () => {
   })
 
   test('boss raid를 종료할 수 있다', async () => {
-    const raidRecord = raidRecords[1]
-    bossRaidCache.data = raidRecord
+    const raidRecord = raidRecords[6]
+    const newBossRaidCache = Object.assign(bossRaidCache)
+    newBossRaidCache.data = raidRecord
     const bossService = require('../../boss/bossService')
     const record = {
       userId: raidRecord.userId,
       raidRecordId: raidRecord.raidRecordId,
     }
+
     await expect(
-      bossService.endBossRaid(bossRaidCache, record),
+      bossService.endBossRaid(newBossRaidCache, record),
     ).resolves.toEqual([1])
   })
 
@@ -91,7 +96,6 @@ describe('boss raid 통합테스트', () => {
       {ranking: {topRankerInfoList: orderedRanks}},
       1,
     )
-
     rankings.topRankerInfoList.forEach((record, index) => {
       expect(record.userId).toEqual(orderedRanks[index].userId)
       expect(Number(record.totalScore)).toEqual(orderedRanks[index].totalScore)

--- a/__tests__/intergration/boss.js
+++ b/__tests__/intergration/boss.js
@@ -87,7 +87,10 @@ describe('boss raid 통합테스트', () => {
   test('boss raid를 랭킹을 조회할 수 있다', async () => {
     const bossService = require('../../boss/bossService')
     const orderedRanks = helper.orderByScore(raidRecords)
-    const rankings = await bossService.getRankers({ranking: orderedRanks}, 1)
+    const rankings = await bossService.getRankers(
+      {ranking: {topRankerInfoList: orderedRanks}},
+      1,
+    )
 
     rankings.topRankerInfoList.forEach((record, index) => {
       expect(record.userId).toEqual(orderedRanks[index].userId)

--- a/boss/RaidValidator.js
+++ b/boss/RaidValidator.js
@@ -50,8 +50,33 @@ const isExcedTime = record => {
   return false
 }
 
+const hasRankingData = bossRaidCache => {
+  const NotFoundRankingException = require('./exception/NotFoundRankingException')
+
+  if (
+    !Object.hasOwn(bossRaidCache, 'ranking') ||
+    bossRaidCache.ranking === undefined ||
+    !Array.isArray(bossRaidCache.ranking.topRankerInfoList) ||
+    bossRaidCache.ranking.topRankerInfoList.length === 0
+  ) {
+    throw new NotFoundRankingException()
+  }
+}
+
+const hasLatestRaidRecord = bossRaidCache => {
+  if (
+    !Object.hasOwn(bossRaidCache, 'data') ||
+    bossRaidCache.data === undefined
+  ) {
+    return false
+  }
+  return true
+}
+
 module.exports = {
   isValid,
   isRaiding,
   isExcedTime,
+  hasRankingData,
+  hasLatestRaidRecord,
 }

--- a/boss/bossService.js
+++ b/boss/bossService.js
@@ -5,13 +5,9 @@ const raidValidator = require('./RaidValidator')
 const NotValidBossRaidRecordException = require('./exception/NotValidBossRaidRecordException')
 const ExcedBossRaidTimeException = require('./exception/ExcedBossRaidTimeException')
 const StartBossRaidException = require('./exception/StartBossRaidException')
-const NotFoundRankingException = require('./exception/NotFoundRankingException')
 
 const getBossState = bossRaidCache => {
-  if (
-    !Object.hasOwn(bossRaidCache, 'data') ||
-    bossRaidCache.data === undefined
-  ) {
+  if (!raidValidator.hasLatestRaidRecord(bossRaidCache)) {
     return dto.getPossibleRaidState()
   }
   if (raidValidator.isRaiding(bossRaidCache.data)) {
@@ -29,6 +25,7 @@ const startBossRaid = async (bossRaidCache, requestRaids) => {
     bossRaidCache.bossState,
     requestRaids,
   )
+
   const result = await bossRepository.createBossRaidRecord(newRecord)
   dto.setBossStateCache(bossRaidCache, result)
   return dto.getStartBossRaidInformation(result)
@@ -54,13 +51,7 @@ const getUserRaidRecordAndTotalScore = async userId => {
 }
 
 const getRankers = async (bossRaidCache, userId) => {
-  if (
-    !Object.hasOwn(bossRaidCache, 'ranking') ||
-    bossRaidCache.ranking === undefined
-  ) {
-    throw new NotFoundRankingException()
-  }
-
+  raidValidator.hasRankingData(bossRaidCache)
   return dto.splitToUserRankingAndAllRanking(bossRaidCache.ranking, userId)
 }
 

--- a/boss/bossService.js
+++ b/boss/bossService.js
@@ -40,8 +40,13 @@ const endBossRaid = async (bossRaidCache, raidRecord) => {
   }
   const result = await bossRepository.updateRaidRecord(bossRaidCache.data)
   const rankRecord = await bossRepository.findRanker()
+  const splitResult = dto.splitToUserRankingAndAllRanking(
+    rankRecord,
+    raidRecord.userId,
+  )
+
   dto.setBossStateCache(bossRaidCache, undefined)
-  dto.setBossRaidRankCache(bossRaidCache, rankRecord)
+  dto.setBossRaidRankCache(bossRaidCache, splitResult)
   return result
 }
 

--- a/boss/dto/raidRecord.js
+++ b/boss/dto/raidRecord.js
@@ -52,11 +52,18 @@ const getStartBossRaidInformation = record => {
 }
 
 const splitToUserRankingAndAllRanking = (records, userId) => {
-  const myRankingInfo = records.filter(record => {
+  if (userId === undefined) {
+    return records
+  }
+
+  const record = records.topRankerInfoList.filter(record => {
     return record.userId === userId
   })[0]
+
+  const myRankingInfo = Object.assign(record)
+
   return {
-    topRankerInfoList: records,
+    topRankerInfoList: records.topRankerInfoList,
     myRankingInfo,
   }
 }

--- a/boss/dto/raidRecord.js
+++ b/boss/dto/raidRecord.js
@@ -51,21 +51,36 @@ const getStartBossRaidInformation = record => {
   }
 }
 
+const getUserRanking = (userId, records) => {
+  if (!Object.hasOwn(records, 'topRankerInfoList')) {
+    return records.filter(record => {
+      return record.userId === userId
+    })[0]
+  }
+  return records.topRankerInfoList.filter(record => {
+    return record.userId === userId
+  })[0]
+}
+
 const splitToUserRankingAndAllRanking = (records, userId) => {
   if (userId === undefined) {
     return records
   }
+  const userRanking = getUserRanking(userId, records)
+  const result = {}
 
-  const record = records.topRankerInfoList.filter(record => {
-    return record.userId === userId
-  })[0]
-
-  const myRankingInfo = Object.assign(record)
-
-  return {
-    topRankerInfoList: records.topRankerInfoList,
-    myRankingInfo,
+  if (userRanking) {
+    const myRankingInfo = Object.assign(userRanking)
+    result.myRankingInfo = myRankingInfo
   }
+
+  if (!Object.hasOwn(records, 'topRankerInfoList')) {
+    result.topRankerInfoList = records
+  } else {
+    result.topRankerInfoList = records.topRankerInfoList
+  }
+
+  return result
 }
 
 module.exports = {

--- a/boss/index.js
+++ b/boss/index.js
@@ -1,9 +1,14 @@
 const express = require('express')
 const router = express.Router()
 const bossController = require('./presentation/bossController')
-const {postValidator, patchValidator} = require('./presentation/bossValidator')
+const {
+  postValidator,
+  patchValidator,
+  getValidator,
+} = require('./presentation/bossValidator')
 
-router.get('/topRankerList', bossController.getRankings)
+router.get('/topRankerList', getValidator, bossController.getRankings)
+
 router.post('/enter', postValidator, bossController.enterBossRaid)
 router.patch('/end', patchValidator, bossController.finishBossRaid)
 router.get('/', bossController.getBossState)

--- a/boss/presentation/bossController.js
+++ b/boss/presentation/bossController.js
@@ -48,11 +48,8 @@ const getRankings = async (validator, req, res, next) => {
       return res.status(StatusCodes.BAD_REQUEST).send(validator.error.message)
     }
     const bossRaidCache = req.app.get('bossRaidCache')
-    const result = await bossService.getRankers(
-      bossRaidCache,
-      validator.value.userId,
-    )
-    return res.status(StatusCodes.OK).send(result)
+    await bossService.getRankers(bossRaidCache, validator.value.userId)
+    return res.status(StatusCodes.OK).send()
   } catch (err) {
     return res.status(err.StatusCodes).send(err.message)
   }

--- a/boss/presentation/bossController.js
+++ b/boss/presentation/bossController.js
@@ -28,7 +28,7 @@ const enterBossRaid = async (validator, req, res, next) => {
   }
 }
 
-const finishBossRaid = async (validator, req, res) => {
+const finishBossRaid = async (validator, req, res, next) => {
   try {
     if (validator.error) {
       return res.status(StatusCodes.BAD_REQUEST).send(validator.error.message)
@@ -42,10 +42,16 @@ const finishBossRaid = async (validator, req, res) => {
   }
 }
 
-const getRankings = async (req, res) => {
+const getRankings = async (validator, req, res, next) => {
   try {
+    if (validator.error) {
+      return res.status(StatusCodes.BAD_REQUEST).send(validator.error.message)
+    }
     const bossRaidCache = req.app.get('bossRaidCache')
-    const result = await bossService.getRankers(bossRaidCache)
+    const result = await bossService.getRankers(
+      bossRaidCache,
+      validator.value.userId,
+    )
     return res.status(StatusCodes.OK).send(result)
   } catch (err) {
     return res.status(err.StatusCodes).send(err.message)

--- a/boss/presentation/bossValidator.js
+++ b/boss/presentation/bossValidator.js
@@ -1,5 +1,9 @@
 const Joi = require('joi')
 
+const getSchema = Joi.object({
+  userId: Joi.number().min(1),
+})
+
 const postSchema = Joi.object({
   userId: Joi.number().min(1),
   level: Joi.number().min(1),
@@ -16,11 +20,17 @@ const patchSchema = Joi.object({
 })
 
 const patchValidator = (req, res, next) => {
-  const result = patchSchema.validate(req.query)
+  const result = patchSchema.validate(req.body)
+  next(result, req, res, next)
+}
+
+const getValidator = (req, res, next) => {
+  const result = getSchema.validate(req.body)
   next(result, req, res, next)
 }
 
 module.exports = {
   postValidator,
   patchValidator,
+  getValidator,
 }

--- a/middlewares/cache.js
+++ b/middlewares/cache.js
@@ -1,4 +1,5 @@
 const bossRepository = require('../boss/bossRepository')
+const dto = require('../boss/dto/raidRecord')
 
 const getRaidRecord = async () => {
   try {
@@ -9,9 +10,17 @@ const getRaidRecord = async () => {
 }
 
 const initRaidRecord = async bossRaidCache => {
-  const cacheRecord = await getRaidRecord()
+  const [cacheRecord, cachedRanking] = await getRaidRecord()
+
   if (cacheRecord) {
     bossRaidCache.data = cacheRecord
+  }
+  if (cachedRanking) {
+    const topRankerInfoList = dto.splitToUserRankingAndAllRanking(cachedRanking)
+
+    bossRaidCache.ranking = {
+      topRankerInfoList,
+    }
   }
 }
 


### PR DESCRIPTION
## 랭킹 조회 버그 수정

보스 레이드를 종료하고 바로 랭킹 조회시 정보를 불러오지 않는 버그 수정

- 테스트 케이스 추가
- 랭킹 데이터 초기화 추가
- cache validation 세분화(최근 레이드 정보 있는지, 최근 랭킹 정보 있는지)
- topRankerInfoList 추가에 맞게 테스트 코드 수정
- topRankerInfoList 추가에 맞게 dto 코드 수정