### PR TITLE
feat: 사용자 입력 raid level과 서버 raid level 통일

### DIFF
--- a/boss/dto/raidRecord.js
+++ b/boss/dto/raidRecord.js
@@ -6,6 +6,7 @@ const getScoreFor = (bossRaidInformation, level) => {
 }
 
 const crateNewRaidBossRecord = (bossRaidInformation, requestRaids) => {
+  standardizeRaidLevel(requestRaids)
   const score = getScoreFor(bossRaidInformation, requestRaids.level)
   return {
     userId: requestRaids.userId,
@@ -51,6 +52,10 @@ const getStartBossRaidInformation = record => {
   }
 }
 
+const standardizeRaidLevel = user => {
+  user.level -= 1
+}
+
 const getUserRanking = (userId, records) => {
   if (!Object.hasOwn(records, 'topRankerInfoList')) {
     return records.filter(record => {
@@ -92,4 +97,5 @@ module.exports = {
   crateEndRaidBossRecord,
   splitToUserRankingAndAllRanking,
   setBossRaidRankCache,
+  standardizeRaidLevel,
 }


### PR DESCRIPTION
## 보스 레이드 레벨 버그

사용자가 요청하는 boss raid level은 1~3, 서버에서 사용하는 boss raid level은 0~2
이 차이에서 오는 버그를 수정하였습니다

- standardizeRaidLevel 추가